### PR TITLE
v0.6.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3175,9 +3175,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.23.3"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e484fd2c8b4cb67ab05a318f1fd6fa8f199fcc30819f08f07d200809dba26c15"
+checksum = "7f1c6c3591120564d64db2261bec5f910ae454f01def849b9c22835a84695e86"
 dependencies = [
  "cfg-if",
  "indoc",
@@ -3193,9 +3193,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.23.3"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc0e0469a84f208e20044b98965e1561028180219e35352a2afaf2b942beff3b"
+checksum = "e9b6c2b34cf71427ea37c7001aefbaeb85886a074795e35f161f5aecc7620a7a"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -3203,9 +3203,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.23.3"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb1547a7f9966f6f1a0f0227564a9945fe36b90da5a93b3933fc3dc03fae372d"
+checksum = "5507651906a46432cdda02cd02dd0319f6064f1374c9147c45b978621d2c3a9c"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -3213,9 +3213,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.23.3"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb6da8ec6fa5cedd1626c886fc8749bdcbb09424a86461eb8cdf096b7c33257"
+checksum = "b0d394b5b4fd8d97d48336bb0dd2aebabad39f1d294edd6bcd2cccf2eefe6f42"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -3225,9 +3225,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.23.3"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38a385202ff5a92791168b1136afae5059d3ac118457bb7bc304c197c2d33e7d"
+checksum = "fd72da09cfa943b1080f621f024d2ef7e2773df7badd51aa30a2be1f8caa7c8e"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -3972,9 +3972,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.16"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+checksum = "e502f78cdbb8ba4718f566c418c52bc729126ffd16baee5baa718cf25dd5a69a"
 
 [[package]]
 name = "tempfile"
@@ -4690,8 +4690,8 @@ checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
 
 [[package]]
 name = "xvc"
-version = "0.6.15"
-source = "git+https://github.com/iesahin/xvc?branch=main#99dca4035974fed210ac9df106abd5bc25ffdd64"
+version = "0.6.16"
+source = "git+https://github.com/iesahin/xvc?branch=main#0420565d4d74e17897f2182c6363b9ca686e1455"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4746,8 +4746,8 @@ dependencies = [
 
 [[package]]
 name = "xvc-config"
-version = "0.6.15"
-source = "git+https://github.com/iesahin/xvc?branch=main#99dca4035974fed210ac9df106abd5bc25ffdd64"
+version = "0.6.16"
+source = "git+https://github.com/iesahin/xvc?branch=main#0420565d4d74e17897f2182c6363b9ca686e1455"
 dependencies = [
  "crossbeam",
  "crossbeam-channel",
@@ -4769,8 +4769,8 @@ dependencies = [
 
 [[package]]
 name = "xvc-core"
-version = "0.6.15"
-source = "git+https://github.com/iesahin/xvc?branch=main#99dca4035974fed210ac9df106abd5bc25ffdd64"
+version = "0.6.16"
+source = "git+https://github.com/iesahin/xvc?branch=main#0420565d4d74e17897f2182c6363b9ca686e1455"
 dependencies = [
  "anyhow",
  "blake2",
@@ -4822,8 +4822,8 @@ dependencies = [
 
 [[package]]
 name = "xvc-ecs"
-version = "0.6.15"
-source = "git+https://github.com/iesahin/xvc?branch=main#99dca4035974fed210ac9df106abd5bc25ffdd64"
+version = "0.6.16"
+source = "git+https://github.com/iesahin/xvc?branch=main#0420565d4d74e17897f2182c6363b9ca686e1455"
 dependencies = [
  "crossbeam-channel",
  "fern",
@@ -4841,8 +4841,8 @@ dependencies = [
 
 [[package]]
 name = "xvc-file"
-version = "0.6.15"
-source = "git+https://github.com/iesahin/xvc?branch=main#99dca4035974fed210ac9df106abd5bc25ffdd64"
+version = "0.6.16"
+source = "git+https://github.com/iesahin/xvc?branch=main#0420565d4d74e17897f2182c6363b9ca686e1455"
 dependencies = [
  "anyhow",
  "blake2",
@@ -4898,8 +4898,8 @@ dependencies = [
 
 [[package]]
 name = "xvc-logging"
-version = "0.6.15"
-source = "git+https://github.com/iesahin/xvc?branch=main#99dca4035974fed210ac9df106abd5bc25ffdd64"
+version = "0.6.16"
+source = "git+https://github.com/iesahin/xvc?branch=main#0420565d4d74e17897f2182c6363b9ca686e1455"
 dependencies = [
  "crossbeam-channel",
  "fern",
@@ -4909,8 +4909,8 @@ dependencies = [
 
 [[package]]
 name = "xvc-pipeline"
-version = "0.6.15"
-source = "git+https://github.com/iesahin/xvc?branch=main#99dca4035974fed210ac9df106abd5bc25ffdd64"
+version = "0.6.16"
+source = "git+https://github.com/iesahin/xvc?branch=main#0420565d4d74e17897f2182c6363b9ca686e1455"
 dependencies = [
  "anyhow",
  "blake2",
@@ -4966,7 +4966,7 @@ dependencies = [
 
 [[package]]
 name = "xvc-py"
-version = "0.6.15"
+version = "0.6.16"
 dependencies = [
  "crossbeam",
  "crossbeam-channel",
@@ -4980,8 +4980,8 @@ dependencies = [
 
 [[package]]
 name = "xvc-storage"
-version = "0.6.15"
-source = "git+https://github.com/iesahin/xvc?branch=main#99dca4035974fed210ac9df106abd5bc25ffdd64"
+version = "0.6.16"
+source = "git+https://github.com/iesahin/xvc?branch=main#0420565d4d74e17897f2182c6363b9ca686e1455"
 dependencies = [
  "anyhow",
  "blake2",
@@ -5037,8 +5037,8 @@ dependencies = [
 
 [[package]]
 name = "xvc-walker"
-version = "0.6.15"
-source = "git+https://github.com/iesahin/xvc?branch=main#99dca4035974fed210ac9df106abd5bc25ffdd64"
+version = "0.6.16"
+source = "git+https://github.com/iesahin/xvc?branch=main#0420565d4d74e17897f2182c6363b9ca686e1455"
 dependencies = [
  "anyhow",
  "crossbeam",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 [dependencies]
 log = "^0.4"
 
-xvc_rust = { package = "xvc", git = "https://github.com/iesahin/xvc", branch = "main", version = "0.6.15", features = [
+xvc_rust = { package = "xvc", git = "https://github.com/iesahin/xvc", branch = "main", version = "0.6.16", features = [
   "reflink",
   "bundled-openssl",
   "bundled-sqlite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xvc-py"
-version = "0.6.15"
+version = "0.6.16"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -17,8 +17,8 @@ xvc_rust = { package = "xvc", git = "https://github.com/iesahin/xvc", branch = "
   "bundled-sqlite",
 ] }
 
-xvc_logging = { package = "xvc-logging", git = "https://github.com/iesahin/xvc", branch = "main", version = "0.6.15" }
-xvc_walker = { package = "xvc-walker", git = "https://github.com/iesahin/xvc", branch = "main", version = "0.6.15" }
+xvc_logging = { package = "xvc-logging", git = "https://github.com/iesahin/xvc", branch = "main", version = "0.6.16" }
+xvc_walker = { package = "xvc-walker", git = "https://github.com/iesahin/xvc", branch = "main", version = "0.6.16" }
 
 # xvc_rust = { package = "xvc", path = "../xvc/lib/" }
 # xvc_walker = { package = "xvc-walker", path = "../xvc/walker/" }
@@ -26,5 +26,5 @@ xvc_walker = { package = "xvc-walker", git = "https://github.com/iesahin/xvc", b
 
 crossbeam-channel = "^0.5"
 crossbeam = "^0.8"
-pyo3 = { version = "^0.23", features = ["extension-module", "abi3-py37"] }
+pyo3 = { version = "^0.24", features = ["extension-module", "abi3-py37"] }
 git-version = "^0.3"

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -39,12 +39,15 @@ impl XvcStorage {
 
         self.xvc_run(cli_opts)
     }
+
     #[pyo3(signature = (name, **opts))]
     fn remove(&self, name: &str, opts: Option<&Bound<PyDict>>) -> PyResult<String> {
         let mut cli_opts = self.cli()?;
         cli_opts.push("remove".to_string());
-        cli_opts.push(name.to_string());
         update_cli_flag(opts, &mut cli_opts, &["help"], "--help")?;
+
+        cli_opts.push("--name".to_string());
+        cli_opts.push(name.to_string());
 
         self.xvc_run(cli_opts)
     }

--- a/tests/test_xvc_storage.py
+++ b/tests/test_xvc_storage.py
@@ -1,9 +1,37 @@
-# def test_storage_list(xvc_repo_with_dir):
-#     assert False
+import tempfile
+import os
+
+
+# How to set virtual env in lazyvim python
+def test_storage_list(xvc_repo_with_dir):
+    temp_dir = tempfile.mkdtemp()
+
+    assert os.path.isdir(temp_dir)
+
+    xvc_repo_with_dir.storage().new_local(name="local", path=temp_dir)
+
+    assert "local" in str(xvc_repo_with_dir.storage().list())
+    assert temp_dir in str(xvc_repo_with_dir.storage().list())
+
+
+def test_storage_remove(xvc_repo_with_dir):
+    # Create a temporary directory to be used with local storage
+    temp_dir = tempfile.mkdtemp()
+
+    assert os.path.isdir(temp_dir)
+
+    xvc_repo_with_dir.storage().new_local(name="my-local-storage", path=temp_dir)
+
+    assert "local" in str(xvc_repo_with_dir.storage().list())
+    assert temp_dir in str(xvc_repo_with_dir.storage().list())
+
+    xvc_repo_with_dir.storage().remove("my-local-storage")
+
+    assert "local" not in str(xvc_repo_with_dir.storage().list())
+    assert temp_dir not in str(xvc_repo_with_dir.storage().list())
+
+
 #
-#
-# def test_storage_remove(xvc_repo_with_dir):
-#     assert False
 #
 #
 # def test_storage_new(xvc_repo_with_dir):


### PR DESCRIPTION
<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR updates the version of the package and its dependencies in `Cargo.toml`, modifies the `remove` function in `src/storage.rs` to include a flag for the name, and adds new tests for storage functionality in `tests/test_xvc_storage.py`.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid
sequenceDiagram
    participant Test
    participant Storage
    participant FileSystem

    Test->>FileSystem: Create temp directory
    Test->>Storage: new_local(name="local", path=temp_dir)
    Storage-->>Test: Success
    
    Test->>Storage: list()
    Storage-->>Test: Contains "local" and temp_dir
    
    Test->>Storage: remove("my-local-storage")
    Storage->>Storage: Process CLI options
    Storage-->>Test: Success
    
    Test->>Storage: list()
    Storage-->>Test: Empty list (storage removed)
```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/iesahin/xvc.py/pull/46/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542>Cargo.toml</a></td><td>Updated package version and dependencies to version 0.6.16.</td></tr>
<tr><td><a href=https://github.com/iesahin/xvc.py/pull/46/files#diff-18c17f16d6477d10ed90360fe38e0e13fc117ecd9548f8f9374236c3ec7f8750>src/storage.rs</a></td><td>Modified the <code>remove</code> function to include a <code>--name</code> flag when calling the CLI.</td></tr>
<tr><td><a href=https://github.com/iesahin/xvc.py/pull/46/files#diff-ab17619761b7135e3b3f4f163ffc174d5965b5c3e5551f0a5f8e227d3d608546>tests/test_xvc_storage.py</a></td><td>Added tests for storage list and remove functionality.</td></tr>

</table>
</details>

*This PR includes files in programming languages that we currently do not support. We have not reviewed files with the extensions `.toml`. <a href=https://docs.callstack.ai/introduction>See list of supported languages.</a>*


</details>
<!-- cal_description_end -->




