### PR TITLE
Configure Dependabot: weekly Wednesday updates, single PR per ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,29 @@
 version: 2
 updates:
-- package-ecosystem: cargo
-  directory: "/"
-  schedule:
-    interval: daily
-    time: '03:00'
-  open-pull-requests-limit: 99
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
- Replaces the existing `cargo`-only, daily config with weekly Wednesday updates covering `cargo`, `pip`, and `github-actions`.
- All packages within each ecosystem are grouped into a single `all-dependencies` PR via a wildcard group, instead of one PR per dependency (the previous `open-pull-requests-limit: 99` is no longer needed with grouping and is dropped).


---
_Generated by [Claude Code](https://claude.ai/code/session_01JNeoVMNcxg4HfNiPMfRt9q)_