### PR TITLE
Upgrade to Rust 2024 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "xvc-py"
 version = "0.7.1-alpha.3"
-edition = "2021"
+edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]

--- a/src/file.rs
+++ b/src/file.rs
@@ -3,7 +3,7 @@ use pyo3::types::{PyDict, PyTuple};
 use xvc_rust::watch;
 
 use crate::update_cli;
-use crate::{update_targets, Xvc};
+use crate::{Xvc, update_targets};
 
 #[pyclass]
 #[derive(Clone, Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,16 +116,16 @@ impl Xvc {
 impl Xvc {
     #[allow(clippy::too_many_arguments)]
     #[new]
-    #[pyo3(signature = 
-            (verbosity=None, 
-             quiet=None, 
-             debug=None, 
-             workdir=None, 
-             no_system_config=None, 
+    #[pyo3(signature =
+            (verbosity=None,
+             quiet=None,
+             debug=None,
+             workdir=None,
+             no_system_config=None,
              no_user_config=None,
-             no_env_config=None, 
-             skip_git=None, 
-             from_ref=None, 
+             no_env_config=None,
+             skip_git=None,
+             from_ref=None,
              to_branch=None))]
     fn new(
         verbosity: Option<u8>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyTuple};
 use xvc_rust::core::types::xvcroot::load_xvc_root;
 use xvc_rust::error::Error as XvcError;
-use xvc_rust::{cli, watch, AbsolutePath, XvcLoadParams, XvcRootOpt};
+use xvc_rust::{AbsolutePath, XvcLoadParams, XvcRootOpt, cli, watch};
 
 pub use pipeline::XvcPipeline;
 pub use storage::XvcStorage;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -353,13 +353,13 @@ pub fn update_cli_tuple(
 
 #[macro_export]
 macro_rules! update_cli {
-    ($opts:expr, $cli_opts:expr, flag [ $($keys:expr),+ ] => $flag:expr) => {
+    ($opts:expr_2021, $cli_opts:expr_2021, flag [ $($keys:expr_2021),+ ] => $flag:expr_2021) => {
         $crate::update_cli_flag($opts, $cli_opts, &[$($keys),+], $flag)?;
     };
-    ($opts:expr, $cli_opts:expr, [ $($keys:expr),+ ] => $flag:expr) => {
+    ($opts:expr_2021, $cli_opts:expr_2021, [ $($keys:expr_2021),+ ] => $flag:expr_2021) => {
         $crate::update_cli_opt($opts, $cli_opts, &[$($keys),+], $flag)?;
     };
-    ($opts:expr, $cli_opts:expr, tuple ( $key1:expr, $key2:expr ) => $flag:expr) => {
+    ($opts:expr_2021, $cli_opts:expr_2021, tuple ( $key1:expr_2021, $key2:expr_2021 ) => $flag:expr_2021) => {
         $crate::update_cli_tuple($opts, $cli_opts, ($key1, $key2), $flag)?;
     };
 }

--- a/src/output.rs
+++ b/src/output.rs
@@ -9,12 +9,13 @@ use log::LevelFilter;
 use pyo3::PyResult;
 
 use xvc_config::XvcVerbosity;
-use xvc_logging::{debug, setup_logging, uwr, XvcOutputLine, XvcOutputSender};
+use xvc_logging::{XvcOutputLine, XvcOutputSender, debug, setup_logging, uwr};
 
 use xvc_rust::{
+    Error as XvcError, XvcRootOpt,
     cli::{XvcCLI, XvcSubCommand},
-    core::{check_ignore, git_checkout_ref, handle_git_automation, root, Error as XvcCoreError},
-    error, file, init, pipeline, storage, Error as XvcError, XvcRootOpt,
+    core::{Error as XvcCoreError, check_ignore, git_checkout_ref, handle_git_automation, root},
+    error, file, init, pipeline, storage,
 };
 
 use crate::XvcPyError;

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -1,8 +1,8 @@
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
-use crate::update_cli;
 use crate::Xvc;
+use crate::update_cli;
 
 #[pyclass]
 #[derive(Clone, Debug)]

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -2,8 +2,8 @@ use pyo3::prelude::*;
 use pyo3::types::PyDict;
 use xvc_rust::watch;
 
-use crate::Xvc;
 use crate::update_cli;
+use crate::Xvc;
 
 #[pyclass]
 #[derive(Clone, Debug)]

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -2,8 +2,8 @@ use pyo3::prelude::*;
 use pyo3::types::PyDict;
 use xvc_rust::watch;
 
-use crate::update_cli;
 use crate::Xvc;
+use crate::update_cli;
 
 #[pyclass]
 #[derive(Clone, Debug)]


### PR DESCRIPTION
## Summary
- Tidy first: fixed pre-existing trailing whitespace on the `#[pyo3(signature = ...)]` attribute on `Xvc::new` (it made `rustfmt` fail with an internal error) and an import ordering issue, then ran `cargo fix --edition` to make the `update_cli!` macro's `expr` fragments explicit (`expr_2021`). Both committed separately with no behavior change under edition 2021.
- Bumped `edition = "2021"` → `"2024"` in `Cargo.toml`.
- Reformatted with `cargo fmt --all` to match the 2024 style edition defaults (import ordering, formatting only).

## Test plan
- [x] `cargo build` — clean
- [x] `cargo clippy --all-targets` — no new warnings vs. baseline (only optional let-chain style suggestions enabled by edition 2024, not applied)
- [x] `maturin develop` + `pytest --forked` — all 32 Python tests pass, identical to the pre-upgrade baseline (`test_xvc_file`, `test_xvc_init`, `test_xvc_pipeline`, `test_xvc_root`, `test_xvc_storage`)
- [x] `cargo fmt --all -- --check` — clean

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MV5g88NNNHcNwZjvzegpcn

---
_Generated by [Claude Code](https://claude.ai/code/session_01MV5g88NNNHcNwZjvzegpcn)_